### PR TITLE
fix: display legacy sections separately

### DIFF
--- a/src/components/Administrator.js
+++ b/src/components/Administrator.js
@@ -1,9 +1,9 @@
 import React from "react";
 
 export const Administrator = () => (
-  <div class="mb-5">
-    <span class="border-rose-800 border-2 bg-rose-100 border-solid text-rose-700 py-1 px-2 rounded-md">
-    Role Administrator
+  <div className="mb-5">
+    <span className="border-rose-800 border-2 bg-rose-100 border-solid text-rose-700 py-1 px-2 rounded-md">
+      Role Administrator
     </span>
   </div>
 );

--- a/src/components/AdministratorOrOwner.js
+++ b/src/components/AdministratorOrOwner.js
@@ -1,9 +1,9 @@
 import React from "react";
 
 export const AdministratorOrOwner = () => (
-  <div class="mb-5">
-    <span class="border-rose-800 border-2 bg-rose-100 border-solid text-rose-700 py-1 px-2 rounded-md">
-    Role Administrator or Owner
+  <div className="mb-5">
+    <span className="border-rose-800 border-2 bg-rose-100 border-solid text-rose-700 py-1 px-2 rounded-md">
+      Role Administrator or Owner
     </span>
   </div>
 );

--- a/src/components/Permission.js
+++ b/src/components/Permission.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export const Permission = ({ name, resource }) => (
   <div className="mb-5">
-    <span class="border-rose-800 border-2 bg-rose-100 border-solid text-rose-700 py-1 px-2 rounded-md">
+    <span className="border-rose-800 border-2 bg-rose-100 border-solid text-rose-700 py-1 px-2 rounded-md">
       Requires <strong>{name}</strong> permission
       {resource ? <strong> on {resource}</strong> : ""}
     </span>

--- a/src/components/Recommended.js
+++ b/src/components/Recommended.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 export const Recommended = () => (
-  <span class="bg-sky-700 px-2 py-1 rounded-md text-white text-xs">
+  <span className="bg-sky-700 px-2 py-1 rounded-md text-white text-xs">
     RECOMMENDED
   </span>
 );

--- a/src/pages/docs/configuration.js
+++ b/src/pages/docs/configuration.js
@@ -5,31 +5,22 @@ import { Link } from "../../components/Link";
 import { Main } from "../../components/Main";
 import { Nav } from "../../components/Nav";
 
-const Legacy = ({ data }) => {
+const Manual = ({ data }) => {
   return (
     <Main>
       <Nav />
       <div className="lg:container mx-auto gap-2 grid grid-cols-9">
-        <div className="col-span-1">
+        <div className="col-span-2">
           {data.allMdx.nodes.map((node) => (
-            <div>
-              <Link
-                key={node.frontmatter.title}
-                to={`/docs/legacy#${node.slug.replace("legacy/", "")}`}
-              >
-                {node.frontmatter.title}
-              </Link>
-            </div>
+            <span>
+              <Link to={`/docs/${node.slug}`}>{node.frontmatter.title}</Link>
+            </span>
           ))}
         </div>
-        <div className="col-span-6 flex flex-col bg-neutral-50 font-sans relative ">
+        <div className="col-span-7 flex flex-col bg-neutral-50 font-sans relative ">
           {data.allMdx.nodes.map((node) => (
             <div>
-              <h1 className="text-blue-700 text-5xl mb-10 mt-5">
-                <a href={`#${node.slug.replace("legacy/", "")}`}>
-                  {node.frontmatter.title}
-                </a>
-              </h1>
+              <h1>{node.frontmatter.title}</h1>
               <MDXRenderer>{node.body}</MDXRenderer>
             </div>
           ))}
@@ -40,8 +31,8 @@ const Legacy = ({ data }) => {
 };
 
 export const query = graphql`
-  query MdxQuery {
-    allMdx(filter: { fileAbsolutePath: { regex: "/legacy/" } }) {
+  query manualQuery {
+    allMdx(filter: { fileAbsolutePath: { regex: "/manual/" } }) {
       nodes {
         body
         slug
@@ -54,4 +45,4 @@ export const query = graphql`
   }
 `;
 
-export default Legacy;
+export default Manual;

--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -31,7 +31,7 @@ const DocsIndex = () => (
           </div>
           <div>
             <h3>
-              <Link to="/docs/legacy">Legacy API Reference</Link>
+              <Link to="/docs/manual">Legacy API Reference</Link>
             </h3>
             <p>API Reference for legacy Virtool releases prior to 5.0.0.</p>
           </div>

--- a/src/pages/docs/manual.js
+++ b/src/pages/docs/manual.js
@@ -4,23 +4,40 @@ import React from "react";
 import { Link } from "../../components/Link";
 import { Main } from "../../components/Main";
 import { Nav } from "../../components/Nav";
+import { find, replace } from "lodash";
 
-const Manual = ({ data }) => {
+const Legacy = ({ data, location }) => {
+  const selectedTitle = location.hash ? replace(location.hash, "#", "") : "";
+
+  const filteredData = selectedTitle
+    ? [find(data.allMdx.nodes, { frontmatter: { title: selectedTitle } })]
+    : data.allMdx.nodes;
+
   return (
     <Main>
       <Nav />
       <div className="lg:container mx-auto gap-2 grid grid-cols-9">
-        <div className="col-span-2">
+        <div className="col-span-1 sticky top-20 self-start">
           {data.allMdx.nodes.map((node) => (
-            <span>
-              <Link to={`/docs/${node.slug}`}>{node.frontmatter.title}</Link>
-            </span>
+            <div key={node.frontmatter.title}>
+              <Link
+                key={node.frontmatter.title}
+                to={`#${node.frontmatter.title}`}
+              >
+                {node.frontmatter.title}
+              </Link>
+            </div>
           ))}
         </div>
-        <div className="col-span-7 flex flex-col bg-neutral-50 font-sans relative ">
-          {data.allMdx.nodes.map((node) => (
-            <div>
-              <h1>{node.frontmatter.title}</h1>
+
+        <div className="col-span-6 flex flex-col bg-neutral-50 font-sans relative ">
+          {filteredData.map((node) => (
+            <div key={node.frontmatter.title}>
+              <h1 className="text-blue-700 text-5xl mb-10 mt-5">
+                <a href={`#${node.frontmatter.title}`}>
+                  {node.frontmatter.title}
+                </a>
+              </h1>
               <MDXRenderer>{node.body}</MDXRenderer>
             </div>
           ))}
@@ -31,8 +48,8 @@ const Manual = ({ data }) => {
 };
 
 export const query = graphql`
-  query manualQuery {
-    allMdx(filter: { fileAbsolutePath: { regex: "/manual/" } }) {
+  query MdxQuery {
+    allMdx(filter: { fileAbsolutePath: { regex: "/legacy/" } }) {
       nodes {
         body
         slug
@@ -45,4 +62,4 @@ export const query = graphql`
   }
 `;
 
-export default Manual;
+export default Legacy;


### PR DESCRIPTION
Legacy docs render at /docs/manual

sidebar works correctly and clicking links result in only the correct guide being displayed. This works when the url is copied and pasted into a different browser.

The only difference over what was specified is that the # symbol is still used. This seemed like the cleanest solution that wouldn't require creating separate page components for each section. 

![Screenshot from 2022-09-16 13-57-30](https://user-images.githubusercontent.com/97321944/190734282-bc60cc9f-e8c5-4e9c-897e-33e800ee2d17.png)
