### PR TITLE
Rastinrashidi/web 20 make side menus sticky

### DIFF
--- a/src/pages/docs/legacy/manual/[...slug].astro
+++ b/src/pages/docs/legacy/manual/[...slug].astro
@@ -38,7 +38,7 @@ const { Content, components } = await entry.render();
 
 <Layout title={entry.data.title}>
   <div class="grid grid-cols-8">
-    <div class="col-span-1">
+    <div class="col-span-1 self-start sticky top-20">
       <Menu sections={sections} baseUrl="/docs/legacy/manual" />
     </div>
     <div class="col-span-7 prose max-w-4xl">


### PR DESCRIPTION
API page already had sticky menu but user manual page did not.